### PR TITLE
Set NODE_ENV=production if not set.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,7 @@ env_dir=$3
 source $bp_dir/lib/common.sh
 
 export_env_dir $env_dir
+export_node_env
 cd $build_dir
 
 head "Building webpack bundle"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -15,3 +15,7 @@ export_env_dir() {
     done
   fi
 }
+
+export_node_env() {
+  export NODE_ENV=${NODE_ENV:-production}
+}


### PR DESCRIPTION
Why? `heroku-buildpack-nodejs` is required to run `heroku-buildpack-webpack` and it sets `NODE_ENV` so we need a consistent environment around them.
